### PR TITLE
OLH-907: Add changelog and set initial version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+- Follow the guidelines on semver.org for assigning version numbers.
+- Mark breaking changes with `BREAKING:`. Be sure to include instructions on how applications should be upgraded.
+- Include a link to your pull request.
+- Don't include changes that are purely internal. The CHANGELOG should be a
+  useful summary for people upgrading their application, not a replication
+  of the commit log.
+
+# 0.1.0
+
+Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "di-cross-service-header",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "di-cross-service-header",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "govuk-frontend": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "di-cross-service-header",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "A header for services using GOV.UK One Login",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Set initial version at `0.1.0`. The semver.org site suggests starting with a development release of `0.1.0` and incrementing the minor version with each subsequent release until software is stable enough to be used in production.

https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase