### PR TITLE
BAU: Fix deploy to GH Pages action

### DIFF
--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -17,10 +17,11 @@ To create a page in your prototype using a pre-built template containing the hea
 
 ![List of templates available to install on the Prototype Kit templates page](/docs/assets/prototype-kit/templates.png)
 
-To set the service name that is displayed in the header, use the following syntax: `{% set serviceName = "My example service name" %}`.
+To set the service name that is displayed in the header, use the following syntax: `{% raw %}{% set serviceName = "My example service name" %}{% endraw %}`.
 
 To set the list of navigation links , use the following syntax:
 ```
+{% raw %}
 {% set navigationItems = [
   {
     href: "#",
@@ -35,24 +36,26 @@ To set the list of navigation links , use the following syntax:
     text: 'Example link 3',
     id: 'id3'
   }]
-%} 
+%}
+{% endraw %}
 ```
 The fields indicate as follows:
 - `href` indicates the link destination, 
 - `text` is the text being displayed, 
 - `id` this should be a unique identifier as it is used to set the active link
 
-To set the currently active link which indicates the page the user is currently on, use the following syntax `{% set activeLinkId = "id3" %}`. The value of `activeLinkId` must match the id of one of the objects in the `navigationItems` array.
+To set the currently active link which indicates the page the user is currently on, use the following syntax `{% raw %}{% set activeLinkId = "id3" %}{% endraw %}`. The value of `activeLinkId` must match the id of one of the objects in the `navigationItems` array.
 
 Add the `set` statements listed above after the `extends` line at the top of the file.
 
 ## Use the header component in an existing page or template
 
 If instead of using the template installation described above, you want to include the header component into one of your existing layouts or templates, the component can be imported using the syntax: 
-`{% from "di-govuk-one-login-service-header/service-header.njk" import govukOneLoginServiceHeader %}`
+`{% raw %}{% from "di-govuk-one-login-service-header/service-header.njk" import govukOneLoginServiceHeader %}{% endraw %}`
 
 The component can then be used like so: 
 ```
+{% raw %}
 {% block header %}
   {{ govukOneLoginServiceHeader({
     serviceName: "My example service name",
@@ -72,4 +75,5 @@ The component can then be used like so:
     activeLinkId: 'servicelink3'
   }) }}
 {% endblock %}
+{% endraw %}
 ```


### PR DESCRIPTION
The deploy to Github pages action is [failing](https://github.com/alphagov/di-govuk-one-login-service-header/actions/runs/5752849111/job/15594742802) after adding the documentation on installing the header with the Prototype Kit.

This is because GH pages uses Jekyll to convert MD into HTML, which uses Liquid as a templating language, which has a very similar syntax to Nunjucks.
The `{% %}` tags used to exemplify usage of the header in `prototype-kit-installation.md` are picked up as Liquid code, causing errors in the deploy to pages action as Liquid does not have the same syntax as Nunjucks so certain keywords such as `set` are not recognised.

This is a workaround which uses Liquid's `{% raw %}...{% endraw %}` tags to escape the Nunjucks/Liquid syntax in the documentation file which should eliminate the build errors.
https://stackoverflow.com/questions/3426182/how-to-escape-liquid-template-tags