### PR TITLE
Add module export to service-header.js

### DIFF
--- a/src/scripts/service-header.js
+++ b/src/scripts/service-header.js
@@ -70,3 +70,5 @@ CrossServiceHeader.prototype.handleMenuButtonClick = function () {
     this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText;
   }
 }
+
+export { CrossServiceHeader };


### PR DESCRIPTION
Adds an ES module export to the service.js file making it easier to use in applications that utilise this kind of javascript.