### PR TITLE
Support overwriting sign out link when using pre-built layout template for Prototype Kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG
+
+Use [semver guidelines](https://semver.org/).
+
+## Unreleased 
+
+* BUG: Support overwriting sign out link when using pre-built layout template for Prototype Kit ([PR #41](https://github.com/govuk-one-login/service-header/pull/41))
+
+## 1.1.0
+
+Initial release

--- a/dist/nunjucks/di-govuk-one-login-service-header/layouts/service-header.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/layouts/service-header.njk
@@ -8,7 +8,8 @@
     serviceName: serviceName, 
     activeLinkId: activeLinkId,
     oneLoginLink: oneLoginLink, 
-    homepageLink: homepageLink
+    homepageLink: homepageLink,
+    signOutLink: signOutLink
   }) }}
 {% endblock %}
 

--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -79,3 +79,9 @@ The component can then be used like so:
   }) &rbrace;&rbrace;
 &lbrace;&percnt; endblock &percnt;&rbrace;
 </code></pre>
+
+## How to update the header if you are using the Prototype Kit 
+
+You may not receive updates or bug fixes automatically. 
+
+To update the header to the most recent version, please run `npm update govuk-one-login-service-header` in your terminal.

--- a/src/nunjucks/layouts/service-header.njk
+++ b/src/nunjucks/layouts/service-header.njk
@@ -8,7 +8,8 @@
     serviceName: serviceName, 
     activeLinkId: activeLinkId,
     oneLoginLink: oneLoginLink, 
-    homepageLink: homepageLink
+    homepageLink: homepageLink,
+    signOutLink: signOutLink
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
**1.  Support over-writing the default href of the Sign out link when using the "Page with GOVUK One Login header" template for the prototype kit.**

The value of this link can be over ruled by passing a custom `signOutLink` value into the `govukOneLoginServiceHeader` macro so users importing the macro directly would be able to set a custom value this way.

However, users using the pre-built template are unable to set a custom `signOutLink` currently. This update should fix that.

**2. Add CHANGELOG**
Even though the header is not yet distributed via a package manager, versioning the header is still valuable for prototype kit users relying on the header as a PK plugin. For these users to receive the newest updates and bug fixes, the version of the package must be updated. Additionally, keeping a log is a good idea for visibility in general.

**3. Add instructions on updating the header package for Prototype Kit users**
... although it's not really PK specific, it's more "if you've installed the header from GH using `npm`" but that's something we only really recommend for PK users for now