### PR TITLE
OLH-1770: Update `govuk-frontend` to the latest version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/**/* linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Use [semver guidelines](https://semver.org/).
 
 - BUG: Support overwriting sign out link when using pre-built layout template for Prototype Kit ([PR #41](https://github.com/govuk-one-login/service-header/pull/41))
 - Add module export to service-header.js ([PR #39](https://github.com/govuk-one-login/service-header/pull/39))
+- Update govuk-frontend to the latest version ([PR #45](https://github.com/govuk-one-login/service-header/pull/45))
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ How you use the styles for the header will be different depending on whether you
 
 Copy the Sass files from this repository into your service's Sass implementation.
 
-Make sure you have added `node_modules/govuk-frontend` to your Sass loadpath. The header code uses this to [simplify its Sass import paths](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#simplify-sass-import-paths).
+Make sure you have added `node_modules/govuk-frontend/dist` to your Sass loadpath. The header code uses this to [simplify its Sass import paths](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#simplify-sass-import-paths).
 
-Alternatively, you can edit the header’s Sass import paths to specify `node_modules/govuk-frontend` for each import.
+Alternatively, you can edit the header’s Sass import paths to specify `node_modules/govuk-frontend/dist` for each import.
 
 ### If you use the GOV.UK Frontend pre-compiled CSS files
 
@@ -184,16 +184,22 @@ There’s [more information about using GDS Transport](https://design-system.ser
 
 The GOV.UK One Login service header uses Javascript to enable 'drop down' behaviour for the header on small screen sizes. The header doesn't rely on Javascript to do anything else.
 
-Copy the code in this repository's Javascript file into your service's Javascript implementation.
+Copy the code from one of this repository's [Javascript files](https://github.com/govuk-one-login/service-header/blob/main/dist/scripts) into your service's Javascript implementation. 
+
+You will only need one of the files:
+
++ `service-header.js` contains the JS required for the header, but leaves initialisation to you. This is so you can run other Javascript functions before initialisation of the header dropdown functionality if you need to. 
++ `service-header-with-init.js` automatically initialises the header component. All you need to do is include this file
+
+Choose one or the other depending on your needs.
+
+The recommendation is to import `service-header.js` and run the initialisation function at a point in your code where it makes sense. 
 
 ### Initialising the header
 
-Copying the header’s Javascript file into your project does not initialise the drop down behaviour. This is so you can run other Javascript functions before initialisation of the header dropdown functionality if you need to.
+If you choose to use `service-header.js`, you will need to initialise the header by importing the `initCrossServiceHeader` function from the file and running `initCrossServiceHeader()` in your code.
 
-You’ll need to initialise the Javascript in your code to make it work. To do this, you need to:
-
-+ include [service-header.js](https://github.com/govuk-one-login/service-header/blob/main/dist/scripts/service-header.js) in your application Javascript - this attaches the function to the window object by default but you can namespace it if you need to
-+ initialise the header by running `new window.CrossServiceHeader(document.querySelector("[data-module='one-login-header']")).init()`
+A basic working example using `service-header.js` can be seen on the [header preview page](https://github.com/govuk-one-login/service-header/blob/main/dist/preview.html).
 
 ### If you don’t use the header’s Javascript
 

--- a/dist/html/header.html
+++ b/dist/html/header.html
@@ -32,27 +32,27 @@
         class="cross-service-header__button cross-service-header__button--one-login js-x-header-toggle">
         <span class="cross-service-header__button-content">One Login</span>
           
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="white"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
-              <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="white"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
+        <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
           
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="black"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="white"/>
-              <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="black"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="white"/>
+        <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
       </button>
       <nav aria-label="GOV.UK One Login menu" class="one-login-header__nav" data-open-class="one-login-header__nav--open" id="one-login-header__nav">
         <ul class="one-login-header__nav__list">
@@ -62,27 +62,27 @@
                 GOV.UK One Login
               </span>
               
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="white"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
-              <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="white"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
+        <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
               
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="black"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="white"/>
-              <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="black"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="white"/>
+        <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
             </a>
           </li>
           <li class="one-login-header__nav__list-item">

--- a/dist/nunjucks/di-govuk-one-login-service-header/template.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/template.njk
@@ -33,16 +33,16 @@ Component options:
   {%- set class = "focus" if modifier == "focus" else "default" %}
   {%- set backgroundColour = "black" if modifier == "focus" else "white" %}
   {%- set personColour = "white" if modifier == "focus" else "#1D70B8" %}
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--{{class}}">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="{{backgroundColour}}"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="{{personColour}}"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="{{personColour}}"/>
-              <circle cx="11" cy="11" r="10" stroke="{{backgroundColour}}" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--{{class}}">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="{{backgroundColour}}"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="{{personColour}}"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="{{personColour}}"/>
+        <circle cx="11" cy="11" r="10" stroke="{{backgroundColour}}" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
 {%- endmacro -%}
 <header class="cross-service-header" role="banner" data-module="one-login-header">
   <div class="one-login-header" data-one-login-header-nav>

--- a/dist/preview.html
+++ b/dist/preview.html
@@ -63,27 +63,27 @@
         class="cross-service-header__button cross-service-header__button--one-login js-x-header-toggle">
         <span class="cross-service-header__button-content">One Login</span>
           
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="white"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
-              <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="white"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
+        <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
           
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="black"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="white"/>
-              <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="black"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="white"/>
+        <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
       </button>
       <nav aria-label="GOV.UK One Login menu" class="one-login-header__nav" data-open-class="one-login-header__nav--open" id="one-login-header__nav">
         <ul class="one-login-header__nav__list">
@@ -93,27 +93,27 @@
                 GOV.UK One Login
               </span>
               
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="white"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
-              <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--default">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="white"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="#1D70B8"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="#1D70B8"/>
+        <circle cx="11" cy="11" r="10" stroke="white" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
               
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="black"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="white"/>
-              <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--focus">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="black"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="white"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="white"/>
+        <circle cx="11" cy="11" r="10" stroke="black" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
             </a>
           </li>
           <li class="one-login-header__nav__list-item">
@@ -185,7 +185,10 @@
   
 </header>
 
-    <script src="./scripts/service-header.js"></script>
-    <script src="./scripts/init-service-header.js"></script>
+    <script type="module" src="./scripts/service-header.js"></script>
+    <script type="module">
+      import { initCrossServiceHeader } from './scripts/service-header.js';
+      initCrossServiceHeader();
+    </script>
   </body>
 </html>

--- a/dist/scripts/init-service-header.js
+++ b/dist/scripts/init-service-header.js
@@ -1,4 +1,0 @@
-var oneLoginHeader = document.querySelector("[data-module='one-login-header']");
-if (oneLoginHeader) {
-  new window.CrossServiceHeader(oneLoginHeader).init();
-}

--- a/dist/scripts/service-header-with-init.js
+++ b/dist/scripts/service-header-with-init.js
@@ -1,6 +1,17 @@
 /**
-* A modified adaptation of the Design System header script
+  * This file is primarily for the GOVUK Prototype Kit service header plugin. 
+  * The PK doesn't seem to support adding ES6 JS modules as dependencies 
+  * on plugins. 
+  * 
+  * DIFFERENCE BETWEEN THIS SCRIPT AND service-header.js
+  * 
+  * This script automatically initialises the header component. 
+  * `service-header.js` contains the JS needed for the header, but leaves 
+  * initialisation to the end user.
+  * 
+  * Choose one or the other depending on your needs.
 */
+
 function CrossServiceHeader ($module) {
   this.$header = $module
   this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
@@ -76,4 +87,4 @@ function initCrossServiceHeader () {
   }
 }
 
-export { CrossServiceHeader, initCrossServiceHeader };
+initCrossServiceHeader();

--- a/dist/styles/service-header.css
+++ b/dist/styles/service-header.css
@@ -16,28 +16,7 @@
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
  
-
-
-
-
-
-
-
-
  
 
 
@@ -52,12 +31,7 @@
 
 
 
-
-
-
-
-
-
+ 
 
 
 
@@ -83,6 +57,12 @@
 
 
  
+ 
+
+
+
+
+
 
 
 
@@ -92,12 +72,6 @@
 
 
  
-
-
-
-
-
-
 
 
 
@@ -159,6 +133,8 @@
 
 
 
+ 
+ 
 
 
 
@@ -173,21 +149,6 @@
 
 
  
-
-
-
-
-
-
-
-
- 
-
-
-
-
-
-
 
 
 
@@ -198,7 +159,7 @@
   margin-right: -15px;
   margin-left: -15px;
 }
-.govuk-grid-row:after {
+.govuk-grid-row::after {
   content: "";
   display: block;
   clear: both;
@@ -349,9 +310,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.1875rem;
+  line-height: 1.3157894737;
   position: relative;
   align-items: center;
   cursor: pointer;
@@ -389,13 +349,6 @@
 @media print {
   .cross-service-header__button {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) {
-  .cross-service-header__button {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print {
@@ -506,9 +459,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.1875rem;
+  line-height: 1.3157894737;
   color: #ffffff;
   background: #0b0c0c;
   border-bottom: 10px solid #1d70b8;
@@ -517,13 +469,6 @@
 @media print {
   .one-login-header {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) {
-  .one-login-header {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print {
@@ -776,9 +721,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 18px;
-  font-size: 1.125rem;
-  line-height: 1.1111111111;
+  font-size: 1.3125rem;
+  line-height: 1.1904761905;
   color: #0b0c0c;
   padding: 15px 0;
   margin: 0;
@@ -791,7 +735,6 @@
 }
 @media (min-width: 40.0625em) {
   .service-header__heading {
-    font-size: 24px;
     font-size: 1.5rem;
     line-height: 1.25;
   }
@@ -833,9 +776,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.1875rem;
+  line-height: 1.3157894737;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -843,13 +785,6 @@
 @media print {
   .service-header__nav-list {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) {
-  .service-header__nav-list {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print {
@@ -864,21 +799,13 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 700;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
   }
 }
 @media print and (min-width: 40.0625em) {
   .service-header__nav-list {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) and (min-width: 40.0625em) {
-  .service-header__nav-list {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print and (min-width: 40.0625em) {

--- a/dist/styles/service-header.scss
+++ b/dist/styles/service-header.scss
@@ -1,4 +1,5 @@
 $govuk-new-link-styles: true;
+$govuk-new-typography-scale: true;
 // dependencies from GOVUK frontend
 // if this is throwing errors, check that you have govuk-frontend installed and that the load paths are correct
 

--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -3,8 +3,7 @@
     "/dist/styles/service-header-no-imports.scss"
   ],
   "scripts": [
-    "/dist/scripts/service-header.js",
-    "/dist/scripts/init-service-header.js"
+    "/dist/scripts/service-header-with-init.js"
   ],
   "nunjucksPaths": [
     "/dist/nunjucks"
@@ -22,5 +21,8 @@
       "importFrom": "di-govuk-one-login-service-header/service-header.njk"
     }
   ],
-  "pluginDependencies": ["govuk-frontend"]
+  "pluginDependencies": [{
+    "packageName": "govuk-frontend",
+    "minVersion": "5.0.0"
+  }]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^4.8.0",
+        "govuk-frontend": "^5.4.0",
         "nunjucks": "^3.2.4"
       },
       "devDependencies": {
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -368,9 +368,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw=="
     },
     "immutable": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "build-templates": "node build.js",
-    "build-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend src/styles/service-header.scss src/styles/service-header.css",
-    "watch-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend --watch src/styles/service-header.scss dist/styles/service-header.css",
+    "build-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend/dist src/styles/service-header.scss src/styles/service-header.css",
+    "watch-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend/dist --watch src/styles/service-header.scss dist/styles/service-header.css",
     "build-all": "npm run build-sass && npm run build-templates"
   },
   "author": "",
@@ -19,7 +19,7 @@
     "sass": "^1.60.0"
   },
   "dependencies": {
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "^5.4.0",
     "nunjucks": "^3.2.4"
   }
 }

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -33,16 +33,16 @@ Component options:
   {%- set class = "focus" if modifier == "focus" else "default" %}
   {%- set backgroundColour = "black" if modifier == "focus" else "white" %}
   {%- set personColour = "white" if modifier == "focus" else "#1D70B8" %}
-        <!--[if gt IE 8]><!-->
-          <span class="cross-service-header__button-icon cross-service-header__button-icon--{{class}}">
-            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
-              <circle cx="11" cy="11" r="11" fill="{{backgroundColour}}"/>
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="{{personColour}}"/>
-              <circle cx="11" cy="7.75" r="3.75" fill="{{personColour}}"/>
-              <circle cx="11" cy="11" r="10" stroke="{{backgroundColour}}" stroke-width="2"/>
-            </svg>
-          </span>
-        <!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+    <span class="cross-service-header__button-icon cross-service-header__button-icon--{{class}}">
+      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+        <circle cx="11" cy="11" r="11" fill="{{backgroundColour}}"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M3.29297 18.8487C4.23255 15.4753 7.32741 13 11.0004 13C14.6731 13 17.7678 15.4749 18.7076 18.848C17.8058 19.7338 16.752 20.4654 15.5889 21H11.0004H6.41097C5.24819 20.4655 4.19463 19.7342 3.29297 18.8487Z" fill="{{personColour}}"/>
+        <circle cx="11" cy="7.75" r="3.75" fill="{{personColour}}"/>
+        <circle cx="11" cy="11" r="10" stroke="{{backgroundColour}}" stroke-width="2"/>
+      </svg>
+    </span>
+  <!--<![endif]-->
 {%- endmacro -%}
 <header class="cross-service-header" role="banner" data-module="one-login-header">
   <div class="one-login-header" data-one-login-header-nav>

--- a/src/preview.njk
+++ b/src/preview.njk
@@ -44,7 +44,10 @@
   </head>
   <body style="margin:0;">
     {{ govukOneLoginServiceHeader({ navigationItems: navigationItems, serviceName: serviceName, activeLinkId: activeLinkId, signOutLink: signOutLink }) }}
-    <script src="./scripts/service-header.js"></script>
-    <script src="./scripts/init-service-header.js"></script>
+    <script type="module" src="./scripts/service-header.js"></script>
+    <script type="module">
+      import { initCrossServiceHeader } from './scripts/service-header.js';
+      initCrossServiceHeader();
+    </script>
   </body>
 </html>

--- a/src/scripts/init-service-header.js
+++ b/src/scripts/init-service-header.js
@@ -1,4 +1,0 @@
-var oneLoginHeader = document.querySelector("[data-module='one-login-header']");
-if (oneLoginHeader) {
-  new window.CrossServiceHeader(oneLoginHeader).init();
-}

--- a/src/scripts/service-header-with-init.js
+++ b/src/scripts/service-header-with-init.js
@@ -1,6 +1,17 @@
 /**
-* A modified adaptation of the Design System header script
+  * This file is primarily for the GOVUK Prototype Kit service header plugin. 
+  * The PK doesn't seem to support adding ES6 JS modules as dependencies 
+  * on plugins. 
+  * 
+  * DIFFERENCE BETWEEN THIS SCRIPT AND service-header.js
+  * 
+  * This script automatically initialises the header component. 
+  * `service-header.js` contains the JS needed for the header, but leaves 
+  * initialisation to the end user.
+  * 
+  * Choose one or the other depending on your needs.
 */
+
 function CrossServiceHeader ($module) {
   this.$header = $module
   this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
@@ -76,4 +87,4 @@ function initCrossServiceHeader () {
   }
 }
 
-export { CrossServiceHeader, initCrossServiceHeader };
+initCrossServiceHeader();

--- a/src/scripts/service-header.js
+++ b/src/scripts/service-header.js
@@ -1,23 +1,41 @@
 /**
 * A modified adaptation of the Design System header script
-* To initialise the One Login header, run:
-* new window.CrossServiceHeader(document.querySelector("[data-module='one-login-header']")).init();
 */
 function CrossServiceHeader ($module) {
   this.$header = $module
   this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
   this.$numberOfNavs = this.$navigation && this.$navigation.length
-}
-/**
-* Initialise header
-*
-* Check for the presence of the header, menu and menu button – if any are
-* missing then there's nothing to do so return early.
-*/
-CrossServiceHeader.prototype.init = function () {
+
+  /**
+  * Handle menu button click
+  *
+  * When the menu button is clicked, change the visibility of the menu and then
+  * sync the accessibility state and menu button state
+  */
+   this.handleMenuButtonClick = function() {
+    this.isOpen = !this.isOpen;
+    this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen);
+    this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen);
+    this.$menuButton.setAttribute('aria-expanded', this.isOpen);
+    if (this.$menuButtonCloseLabel && this.$menuButtonOpenLabel) {
+      this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel));
+    }
+    if (this.$menuButtonCloseText && this.$menuButtonOpenText) {
+      this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText;
+    }
+  }
+
+  /**
+  * Initialise header
+  *
+  * Check for the presence of the header, menu and menu button – if any are
+  * missing then there's nothing to do so return early.
+  */
+  
   if (!this.$header && !this.$numberOfNavs) {
     return
   }
+  
   /**
   * The header can render with one or two navigation elements which collapse 
   * into dropdowns on the mobile variation. This initialises the dropdown 
@@ -51,24 +69,11 @@ CrossServiceHeader.prototype.init = function () {
   }
 }
 
-
-/**
-* Handle menu button click
-*
-* When the menu button is clicked, change the visibility of the menu and then
-* sync the accessibility state and menu button state
-*/
-CrossServiceHeader.prototype.handleMenuButtonClick = function () {
-  this.isOpen = !this.isOpen;
-  this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen);
-  this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen);
-  this.$menuButton.setAttribute('aria-expanded', this.isOpen);
-  if (this.$menuButtonCloseLabel && this.$menuButtonOpenLabel) {
-    this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel));
-  }
-  if (this.$menuButtonCloseText && this.$menuButtonOpenText) {
-    this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText;
+function initCrossServiceHeader () {
+  const oneLoginHeader = document.querySelector("[data-module='one-login-header']");
+  if (oneLoginHeader && CrossServiceHeader) {
+    new CrossServiceHeader(oneLoginHeader);
   }
 }
 
-export { CrossServiceHeader };
+export { CrossServiceHeader, initCrossServiceHeader };

--- a/src/styles/service-header.css
+++ b/src/styles/service-header.css
@@ -16,28 +16,7 @@
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
  
-
-
-
-
-
-
-
-
  
 
 
@@ -52,12 +31,7 @@
 
 
 
-
-
-
-
-
-
+ 
 
 
 
@@ -83,6 +57,12 @@
 
 
  
+ 
+
+
+
+
+
 
 
 
@@ -92,12 +72,6 @@
 
 
  
-
-
-
-
-
-
 
 
 
@@ -159,6 +133,8 @@
 
 
 
+ 
+ 
 
 
 
@@ -173,21 +149,6 @@
 
 
  
-
-
-
-
-
-
-
-
- 
-
-
-
-
-
-
 
 
 
@@ -198,7 +159,7 @@
   margin-right: -15px;
   margin-left: -15px;
 }
-.govuk-grid-row:after {
+.govuk-grid-row::after {
   content: "";
   display: block;
   clear: both;
@@ -349,9 +310,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.1875rem;
+  line-height: 1.3157894737;
   position: relative;
   align-items: center;
   cursor: pointer;
@@ -389,13 +349,6 @@
 @media print {
   .cross-service-header__button {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) {
-  .cross-service-header__button {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print {
@@ -506,9 +459,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.1875rem;
+  line-height: 1.3157894737;
   color: #ffffff;
   background: #0b0c0c;
   border-bottom: 10px solid #1d70b8;
@@ -517,13 +469,6 @@
 @media print {
   .one-login-header {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) {
-  .one-login-header {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print {
@@ -776,9 +721,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 18px;
-  font-size: 1.125rem;
-  line-height: 1.1111111111;
+  font-size: 1.3125rem;
+  line-height: 1.1904761905;
   color: #0b0c0c;
   padding: 15px 0;
   margin: 0;
@@ -791,7 +735,6 @@
 }
 @media (min-width: 40.0625em) {
   .service-header__heading {
-    font-size: 24px;
     font-size: 1.5rem;
     line-height: 1.25;
   }
@@ -833,9 +776,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.1875rem;
+  line-height: 1.3157894737;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -843,13 +785,6 @@
 @media print {
   .service-header__nav-list {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) {
-  .service-header__nav-list {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print {
@@ -864,21 +799,13 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 700;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
   }
 }
 @media print and (min-width: 40.0625em) {
   .service-header__nav-list {
     font-family: sans-serif;
-  }
-}
-@media (min-width: 40.0625em) and (min-width: 40.0625em) {
-  .service-header__nav-list {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 }
 @media print and (min-width: 40.0625em) {

--- a/src/styles/service-header.scss
+++ b/src/styles/service-header.scss
@@ -1,4 +1,5 @@
 $govuk-new-link-styles: true;
+$govuk-new-typography-scale: true;
 // dependencies from GOVUK frontend
 // if this is throwing errors, check that you have govuk-frontend installed and that the load paths are correct
 


### PR DESCRIPTION
Bump govuk-frontend from v4.8.0 to v5.4.0:

- update `govuk-frontend` load paths to reflect the new folder structure of the package (including `/dist`)
- enable new typography scale – this means that the OL and service menu links are larger on mobile now (from 16px to 19px). The service heading is also larger on mobile, with slightly tweaked line heights. This has been signed off by UCD
- refactor service header script. `govuk-frontend` 5.0.0 removed support for IE11 and introduced JS modules. Tweak the OL service header script in the interest of modularity. Simplify initialisation script
- fix broken GOVUK OL header preview (adding `type="module"` to the import script)

Also: hide autogenerated `dist` files from the preview on GH.

Fixes #37. 