### PR TITLE
OLH-2363: Add documentation for devs working on header

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### What changed
+
+<!-- Describe the changes in detail - the "what"-->
+
+### Why did it change
+
+<!-- Describe the reason these changes were made - the "why" -->
+
+### Related links
+
+<!-- List any related PRs -->
+<!-- List any related ADRs or RFCs -->
+
+### Checklists
+- [ ] design changes have been reviewed by a member of the UCD team
+- [ ] the CHANGELOG.md file has been updated with a log of the changes in this PR
+- [ ] the `npm run build-all` task was run and the outputs were committed
+
+### Testing
+
+<!-- Outline any testing you have done and any testing that needs to take place -->

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can [preview the header in your browser](https://govuk-one-login.github.io/s
 
 ![A screenshot of the GOV.UK One Login header. It has 2 sections: a black section at the top showing the GOV.UK crown logo, a link saying "GOV.UK One Login", which takes you into your account, and a "Sign out" button. Below this section is a grey section, displaying the name of a government service and internal links within that service. Those just have placeholder text, so read "Service name" and "Service link 1" and so on. The black and grey sections are divided by a blue bar, like on the GOV.UK homepage.](service-header-larger-screen.png)
 
+## How to contribute to the service header
+
+If you are a developer working on this project, familiarise yourself with the notes on [this page](docs/dev-contribution-notes.md).
+
 ## Contacting the maintainers
 
 Cross-Government Slack: use the [#govuk-one-login](https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC) channel

--- a/docs/dev-contribution-notes.md
+++ b/docs/dev-contribution-notes.md
@@ -1,0 +1,39 @@
+# How to make changes on the service header
+
+## Brief overview
+
+The setup is fairly simple: 
+
+The source code lives in the `/src` folder and consists of sass files, nunjucks templates and JavaScript (to initialise the dropdown behaviour on mobile). 
+
+Dev work should take place in `/src`. The `npm run build-all` script copies and compiles files into `/dist`.
+
+The `npm run build-templates` command compiles the header template code into HTML and generates a header preview page at `/dist/preview.html`. You can open the HTML file in a browser, or start a simple local server to preview the header locally.
+
+There is a `watch-sass` script which is fairly self-explanatory. 
+
+## Before you open a PR
+
+1. Ensure you've `npm run build-all` and committed the outputs. This generates the contents of the `/dist` folder.
+2. Ensure your change is documented in the `CHANGELOG`, following the preexisting format. Please label your entry with BUG/MAJOR/MINOR.
+If you're not sure which label is most appropriate, please read the guidance on [semver guidelines](https://semver.org/).
+You don't need to document any change that would be irrelevant for an external consumer of the component (e.g. changes to internal documentation).
+
+## Updating the version of the header package
+
+On a new branch:
+
+- run `npm version major | minor | patch` (depending on the nature of the unreleased changes)
+- update the version in the CHANGELOG
+
+Create a new PR with the changes above.
+
+### Why is this needed
+
+The original intention was to eventually publish the header to npm, but this hasn't taken place yet.
+Therefore the current recommendation for consumers of the service header is to copy the assets from the `/dist` folder into their own applications.
+
+However, the `npm install` command allows installation direct from a GitHub repo, so long as the repo has the correct format.
+Some may opt to install the header using `npm` in favour of copying the files manually. 
+
+For these users in particular (but all users, in general), it is useful to maintain a versioned change log on the header component.


### PR DESCRIPTION
Add documentation aimed at internal developers working on the header component. 

The documentation outlines noteworthy information about the setup on the repo (e.g. repo structure, how to preview the header, tasks to run). It also includes guidance for semantic versioning and changelog maintenance.

Add github PR template with checklist of reminders – ideally some of the manual pre-commit tasks should be automated but this should do for now.