### PR TITLE
OLH-2634: Fix PK plugin issues

### DIFF
--- a/build.js
+++ b/build.js
@@ -53,16 +53,27 @@ fs.cp('src/scripts/service-header.js', 'dist/scripts/service-header.js', { recur
   console.log('copied main header script to dist folder');
 })
 
+fs.cp('src/scripts/service-header.js', 'dist/scripts/service-header.js', function (err) {
+  fs.appendFileSync('dist/scripts/service-header.js',fs.readFileSync("src/scripts/export.js").toString(), (err) => {
+    if (err) {
+      throw err;
+    }
+    else {
+      console.log("created service-header.js")
+    }
+  });
+});
+
 fs.cp('src/scripts/service-header.js', 'dist/scripts/init-service-header.js', function (err) {
-  fs.appendFileSync('dist/scripts/init-service-header.js', fs.readFileSync('src/scripts/init-service-header.js').toString(), (err) => {
+  fs.appendFileSync('dist/scripts/init-service-header.js',fs.readFileSync("src/scripts/init-service-header.js").toString(), (err) => {
     if (err) {
       throw err;
     }
     else {
       console.log("created init-service-header.js")
     }
-  }); 
-})
+  });
+});
 
 fs.cp('src/styles', 'dist/styles', { recursive: true } , function (err) {
   if (err) throw err;

--- a/dist/nunjucks/di-govuk-one-login-service-header/layouts/service-header.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/layouts/service-header.njk
@@ -1,17 +1,59 @@
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
-
 {% from "../service-header.njk" import govukOneLoginServiceHeader %}
 
 {% block header %}
-  {{ govukOneLoginServiceHeader({ 
-    navigationItems: navigationItems, 
-    serviceName: serviceName, 
-    activeLinkId: activeLinkId,
-    oneLoginLink: oneLoginLink, 
-    homepageLink: homepageLink,
-    signOutLink: signOutLink,
-    serviceNavigationParams: serviceNavigationParams
-  }) }}
+    {%- if navigationItems -%}
+      {%- set navArr = [] -%}
+      {%- for item in navigationItems -%}
+        {{- '' if navArr.push({
+            href: item.href,
+            text: item.text,
+            active: item.id == activeLinkId
+        }) -}}
+      {%- endfor -%}
+      {{ govukOneLoginServiceHeader({
+        serviceNavigationParams: {
+          serviceName: serviceName
+          serviceUrl: serviceUrl,
+          menuButtonText: menuButtonText,
+          menuButtonLabel: menuButtonLabel,
+          navigation: navArr,
+          navigationLabel: navigationLabel,
+          navigationClasses: navigationClasses,
+          attributes: attributes,
+          classes: classes,
+          ariaLabel: ariaLabel
+        },
+        signOutLink: signOutLink,
+        oneLoginLink: oneLoginLink
+      }) if serviceName }}
+    {%- elif navigation -%}
+      {{ govukOneLoginServiceHeader({
+        signOutLink: signOutLink,
+        oneLoginLink: oneLoginLink,
+        serviceNavigationParams: {
+          serviceName: serviceName,
+          serviceUrl: serviceUrl,
+          navigation: navigation,
+          menuButtonText: menuButtonText,
+          menuButtonLabel: menuButtonLabel,
+          navigationLabel: navigationLabel,
+          navigationClasses: navigationClasses,
+          attributes: attributes,
+          classes: classes,
+          ariaLabel: ariaLabel
+        }
+      }) if serviceName }}
+    {%- else -%}
+      {{ govukOneLoginServiceHeader({ 
+        serviceName: serviceName, 
+        serviceUrl: serviceUrl,
+        signOutLink: signOutLink,
+        oneLoginLink: oneLoginLink,
+        menuButtonText: menuButtonText,
+        menuButtonLabel: menuButtonLabel
+      })}}
+    {%- endif -%}
 {% endblock %}
 
 {% block main %}

--- a/dist/nunjucks/di-govuk-one-login-service-header/template.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/template.njk
@@ -26,7 +26,7 @@ Component options:
   - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://home.account.gov.uk/"
   - serviceNavigationParams (object): Options for the service navigation component. Accepts all the options listed under "Nunjucks macro options" on the Design System [service navigation component page](https://design-system.service.gov.uk/components/service-navigation/). The service nav bar will not render unless serviceName is specified
 #}
-{%- from "../../node_modules/govuk-frontend/dist/govuk/components/service-navigation/macro.njk" import govukServiceNavigation -%}
+{%- from "node_modules/govuk-frontend/dist/govuk/components/service-navigation/macro.njk" import govukServiceNavigation -%}
 {%- set oneLoginLink = params.oneLoginLink if params.oneLoginLink else "https://home.account.gov.uk/" -%}
 {%- set homepageLink = params.homepageLink if params.homepageLink else "https://www.gov.uk/" -%}
 {%- set signOutLink = params.signOutLink if params.signOutLink else "https://home.account.gov.uk/sign-out" -%}

--- a/dist/scripts/init-service-header.js
+++ b/dist/scripts/init-service-header.js
@@ -1,5 +1,6 @@
 /**
 * A modified adaptation of the Design System header script
+* Bundled into dist/scripts/init-service-header.js and dist/scripts/service-header.js
 */
 function CrossServiceHeader ($module) {
   this.$header = $module
@@ -74,8 +75,7 @@ function initCrossServiceHeader () {
     new CrossServiceHeader(oneLoginHeader);
   }
 }
-
-export { CrossServiceHeader, initCrossServiceHeader };/**
+/**
   * This file is here to bundle the init-service-header.js script for the GOVUK Prototype Kit service header plugin. 
   * The PK doesn't seem to support adding ES6 JS modules as dependencies 
   * on plugins. 

--- a/dist/scripts/service-header.js
+++ b/dist/scripts/service-header.js
@@ -1,5 +1,6 @@
 /**
 * A modified adaptation of the Design System header script
+* Bundled into dist/scripts/init-service-header.js and dist/scripts/service-header.js
 */
 function CrossServiceHeader ($module) {
   this.$header = $module
@@ -74,5 +75,9 @@ function initCrossServiceHeader () {
     new CrossServiceHeader(oneLoginHeader);
   }
 }
-
+/**
+  * This gets appended to dist/scripts/service-header.js to make it 
+  * import-able as a JS module
+  * 
+*/
 export { CrossServiceHeader, initCrossServiceHeader };

--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -19,30 +19,36 @@ To create a page in your prototype using a pre-built template containing the hea
 
 To set the service name that is displayed in the header, use the following syntax: <code>&lbrace;&percnt; set serviceName = "My example service name" &percnt;&rbrace;</code>.
 
+As of v3.0.0 of the GOV.UK One Login Service Header, it includes the Design System [service navigation component](https://design-system.service.gov.uk/components/service-navigation/).
+If you are using the latest version of the GOV.UK One Login Service Header, please make sure the GOV.UK Frontend plugin has also been updated to the latest version. You might experience errors otherwise.
+
+The options in the Nunjucks macro options table on the Design System service navigation component page can be defined as Nunjucks template variables.
+
+For example, <code>&lbrace;&percnt; set menuButtonText = "Custom Menu Button" &percnt;&rbrace;</code> will change the text of the service navigation mobile navigation menu toggle.
+
 To set the list of navigation links , use the following syntax:
 <pre><code>
-&lbrace;&percnt; set navigationItems = [
-  {
-    href: "#",
-    text: 'Example link 1',
-    id: 'id1'
-  },{
-    href: "#",
-    text: 'Example link 2',
-    id: 'id2'
-  },{
-    href: "#",
-    text: 'Example link 3',
-    id: 'id3'
-  }]
+&lbrace;&percnt; set navigation = [
+    {
+      href: "#nav1",
+      text: "Navigation item 1"
+    },
+    {
+      href: "#nav2",
+      text: "Navigation item 2",
+      active: true
+    },
+    {
+      href: "#nav3",
+      text: "Navigation item 3"
+    }
+  ]
 &percnt;&rbrace; 
 </code></pre>
 The fields indicate as follows:
 - `href` indicates the link destination, 
 - `text` is the text being displayed, 
-- `id` this should be a unique identifier as it is used to set the active link
-
-To set the currently active link which indicates the page the user is currently on, use the following syntax <code>&lbrace;&percnt; set activeLinkId = "id3" &percnt;&rbrace;</code>. The value of `activeLinkId` must match the id of one of the objects in the `navigationItems` array.
+- `active` this is an optional parameter which indicates that the user is within this group of pages in the navigation hierarchy. It adds an underline to the link.
 
 To overwrite the destination for the GOV.UK link in the header, use <code>&lbrace;&percnt; set homepageLink = "https://example.service.gov.uk/" &percnt;&rbrace;</code>. The link goes to "https://www.gov.uk/" by default.
 
@@ -61,21 +67,24 @@ The component can then be used like so:
 <pre><code>
 &lbrace;&percnt; block header &percnt;&rbrace;
   &lbrace;&lbrace; govukOneLoginServiceHeader({
-    serviceName: "My example service name",
-    navigationItems: [{
-      href: "#",
-      text: 'service link 1',
-      id: 'servicelink1'
-    },{
-      href: "#",
-      text: 'service link 2',
-      id: 'servicelink2'
-    },{
-      href: "#",
-      text: 'service link 3',
-      id: 'servicelink3'
-    }],
-    activeLinkId: 'servicelink3'
+    signOutLink: "/test-signout",
+    oneLoginLink: "/test-one-login",
+    serviceNavigationParams: { 
+      navigation: [
+      {
+        href: "#navigation1", 
+        text: "Navigation item 1" 
+      },{
+        href: "#navigation2", 
+        text: "Navigation item 2",
+        active: true
+      },{
+        href: "#navigation3", 
+        text: "Navigation item 3"
+      }], 
+      serviceName: "Test service name",
+      navigationLabel: "Test label" 
+    }
   }) &rbrace;&rbrace;
 &lbrace;&percnt; endblock &percnt;&rbrace;
 </code></pre>

--- a/src/nunjucks/layouts/service-header.njk
+++ b/src/nunjucks/layouts/service-header.njk
@@ -1,17 +1,52 @@
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
-
 {% from "../service-header.njk" import govukOneLoginServiceHeader %}
 
 {% block header %}
-  {{ govukOneLoginServiceHeader({ 
-    navigationItems: navigationItems, 
-    serviceName: serviceName, 
-    activeLinkId: activeLinkId,
-    oneLoginLink: oneLoginLink, 
-    homepageLink: homepageLink,
-    signOutLink: signOutLink,
-    serviceNavigationParams: serviceNavigationParams
-  }) }}
+    {%- if navigationItems -%}
+      {%- set navArr = [] -%}
+      {%- for item in navigationItems -%}
+        {{- '' if navArr.push({
+            href: item.href,
+            text: item.text,
+            active: item.id == activeLinkId
+        }) -}}
+      {%- endfor -%}
+      {{ govukOneLoginServiceHeader({
+        serviceNavigationParams: {
+          menuButtonText: menuButtonText,
+          menuButtonLabel: menuButtonLabel,
+          navigation: navArr,
+          serviceName: serviceName
+        },
+        signOutLink: signOutLink,
+        oneLoginLink: oneLoginLink
+      }) if serviceName }}
+    {%- elif navigation -%}
+      {{ govukOneLoginServiceHeader({
+        signOutLink: signOutLink,
+        oneLoginLink: oneLoginLink,
+        serviceNavigationParams: {
+          serviceName: serviceName,
+          navigation: navigation,
+          menuButtonText: menuButtonText,
+          menuButtonLabel: menuButtonLabel,
+          navigationLabel: navigationLabel,
+          serviceUrl: serviceUrl,
+          navigationClasses: navigationClasses,
+          attributes: attributes,
+          classes: classes
+        }
+      }) if serviceName }}
+    {%- else -%}
+      {{ govukOneLoginServiceHeader({ 
+        serviceName: serviceName, 
+        serviceUrl: serviceUrl,
+        signOutLink: signOutLink,
+        oneLoginLink: oneLoginLink,
+        menuButtonText: menuButtonText,
+        menuButtonLabel: menuButtonLabel
+      })}}
+    {%- endif -%}
 {% endblock %}
 
 {% block main %}

--- a/src/nunjucks/layouts/service-header.njk
+++ b/src/nunjucks/layouts/service-header.njk
@@ -13,10 +13,16 @@
       {%- endfor -%}
       {{ govukOneLoginServiceHeader({
         serviceNavigationParams: {
+          serviceName: serviceName
+          serviceUrl: serviceUrl,
           menuButtonText: menuButtonText,
           menuButtonLabel: menuButtonLabel,
           navigation: navArr,
-          serviceName: serviceName
+          navigationLabel: navigationLabel,
+          navigationClasses: navigationClasses,
+          attributes: attributes,
+          classes: classes,
+          ariaLabel: ariaLabel
         },
         signOutLink: signOutLink,
         oneLoginLink: oneLoginLink
@@ -27,14 +33,15 @@
         oneLoginLink: oneLoginLink,
         serviceNavigationParams: {
           serviceName: serviceName,
+          serviceUrl: serviceUrl,
           navigation: navigation,
           menuButtonText: menuButtonText,
           menuButtonLabel: menuButtonLabel,
           navigationLabel: navigationLabel,
-          serviceUrl: serviceUrl,
           navigationClasses: navigationClasses,
           attributes: attributes,
-          classes: classes
+          classes: classes,
+          ariaLabel: ariaLabel
         }
       }) if serviceName }}
     {%- else -%}

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -26,7 +26,7 @@ Component options:
   - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://home.account.gov.uk/"
   - serviceNavigationParams (object): Options for the service navigation component. Accepts all the options listed under "Nunjucks macro options" on the Design System [service navigation component page](https://design-system.service.gov.uk/components/service-navigation/). The service nav bar will not render unless serviceName is specified
 #}
-{%- from "../../node_modules/govuk-frontend/dist/govuk/components/service-navigation/macro.njk" import govukServiceNavigation -%}
+{%- from "node_modules/govuk-frontend/dist/govuk/components/service-navigation/macro.njk" import govukServiceNavigation -%}
 {%- set oneLoginLink = params.oneLoginLink if params.oneLoginLink else "https://home.account.gov.uk/" -%}
 {%- set homepageLink = params.homepageLink if params.homepageLink else "https://www.gov.uk/" -%}
 {%- set signOutLink = params.signOutLink if params.signOutLink else "https://home.account.gov.uk/sign-out" -%}

--- a/src/scripts/export.js
+++ b/src/scripts/export.js
@@ -1,0 +1,6 @@
+/**
+  * This gets appended to dist/scripts/service-header.js to make it 
+  * import-able as a JS module
+  * 
+*/
+export { CrossServiceHeader, initCrossServiceHeader };

--- a/src/scripts/service-header.js
+++ b/src/scripts/service-header.js
@@ -1,5 +1,6 @@
 /**
 * A modified adaptation of the Design System header script
+* Bundled into dist/scripts/init-service-header.js and dist/scripts/service-header.js
 */
 function CrossServiceHeader ($module) {
   this.$header = $module
@@ -74,5 +75,3 @@ function initCrossServiceHeader () {
     new CrossServiceHeader(oneLoginHeader);
   }
 }
-
-export { CrossServiceHeader, initCrossServiceHeader };


### PR DESCRIPTION

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change
The relative load path to the Design System service nav component was breaking when the header was being used as a PK plugin. `../../node_modules/etc` would not resolve from `dist/nunjucks/di-govuk-one-login-service-header/template.njk` when installed as a plugin with the Prototype Kit as nothing exists at `../../node_modules` in that context.

The init all script was also breaking due to a misplaced `export` statement.


<!-- Describe the reason these changes were made - the "why" -->

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

### Checklists

- [x] the CHANGELOG.md file has been updated with a log of the changes in this PR
- [x] the `npm run build-all` task was run and the outputs were committed

### Testing
Steps:
1. create a new prototype kit prototype locally following [these instructions](https://prototype-kit.service.gov.uk/docs/install/create-a-prototype)
2. install this branch's version of the service header `npm install github:alphagov/di-govuk-one-login-service-h
eader#OLH-2634-pk-probs`
3. run the PK locally `npm run dev`
4. check http://localhost:3000/manage-prototype/plugins and ensure the service header plugin and GOV.UK Frontend plugin are using the latest versions

The following should be true: 
- the `Page with GOVUK One Login header` template on `/manage-prototype/templates` should show the header without errors (secondary nav would not be present – this is okay)
- when you create a new page from the template (using the create option on the templates page), and you set parameters as instructed in the documentation, the page should render with the header as expected 
- when you use the standalone component on a different template as instructed in the documentation,  the component should render as expected.
- the component should ALSO render as expected when invoked with the old style of parameters


<!-- Outline any testing you have done and any testing that needs to take place -->
