### PR TITLE
BAU: Update main parameter in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "govuk-one-login-service-header",
   "version": "3.0.1",
   "description": "A header for services using GOV.UK One Login",
-  "main": "index.js",
+  "main": "dist/scripts/service-header.js",
+  "type": "module",
   "files": [
     "dist",
     "govuk-prototype-kit.config.json"


### PR DESCRIPTION
The value of the main parameter in package.json was set to the default `index.js` which does not actually exist. 

This update configures it to the service header JS file which should make it easier to import/initialise the script using ES6 import syntax by consumers who choose this approach.


