### PR TITLE
OLH-2604: Bump v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Use [semver guidelines](https://semver.org/).
 
 ## Unreleased
+
+## 3.1.0
 - OLH-2604: Add rebranded header ([PR #67](https://github.com/govuk-one-login/service-header/pull/67))
 
 ## 3.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "govuk-one-login-service-header",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "govuk-one-login-service-header",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "govuk-frontend": "^5.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "govuk-one-login-service-header",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A header for services using GOV.UK One Login",
   "main": "dist/scripts/service-header.js",
   "type": "module",


### PR DESCRIPTION
Bump version of header to 3.1.0. 

Technically speaking, the deadline for making this publicly available is 14th July.  So we might want to hold off until then to merge this in and publish the [draft release notes](https://github.com/govuk-one-login/service-header/releases/edit/untagged-b656f25b3647687622f4)?