### PR TITLE
BAU: Hide GOVUK OL icon SVG from screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Use [semver guidelines](https://semver.org/).
 
 ## Unreleased
+- BAU: Hide GOVUK OL icon SVG from screen readers ([PR #80](https://github.com/govuk-one-login/service-header/pull/80))
 
 ## 3.1.1
 - OLH-2934: Enable rebrand flag for PK layout ([PR #69](https://github.com/govuk-one-login/service-header/pull/69))

--- a/dist/html/header-rebranded.html
+++ b/dist/html/header-rebranded.html
@@ -42,7 +42,7 @@
         class="rebranded-cross-service-header__toggle js-x-header-toggle">
         <span class="rebranded-cross-service-header__toggle-content-wrapper">
           
-  <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo ">
+  <svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo " aria-hidden="true">
     <path d="M300.002 312.261C249.445 312.261 208.346 271.165 208.346 220.608C208.346 170.051 249.445 128.954 300.002 128.954C350.559 128.954 391.655 170.051 391.655 220.608C391.655 271.165 350.559 312.261 300.002 312.261ZM300.002 170.892C272.673 170.892 250.389 193.175 250.389 220.504C250.389 247.83 272.673 270.113 300.002 270.113C327.33 270.113 349.611 247.83 349.611 220.504C349.611 193.175 327.33 170.892 300.002 170.892Z" />
     <path d="M221.275 471.046H179.231V365.202H420.769V407.246H221.275V471.046Z"/>
   </svg>
@@ -55,7 +55,7 @@
             <a class="rebranded-one-login-header__nav__link" href="https://home.account.gov.uk/">
               <span class="rebranded-one-login-header__nav__link-content">
                 
-  <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo rebranded-cross-service-header__logo--nav">
+  <svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo rebranded-cross-service-header__logo--nav" aria-hidden="true">
     <path d="M300.002 312.261C249.445 312.261 208.346 271.165 208.346 220.608C208.346 170.051 249.445 128.954 300.002 128.954C350.559 128.954 391.655 170.051 391.655 220.608C391.655 271.165 350.559 312.261 300.002 312.261ZM300.002 170.892C272.673 170.892 250.389 193.175 250.389 220.504C250.389 247.83 272.673 270.113 300.002 270.113C327.33 270.113 349.611 247.83 349.611 220.504C349.611 193.175 327.33 170.892 300.002 170.892Z" />
     <path d="M221.275 471.046H179.231V365.202H420.769V407.246H221.275V471.046Z"/>
   </svg>

--- a/dist/nunjucks/di-govuk-one-login-service-header/template.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/template.njk
@@ -33,7 +33,7 @@ Component options:
 
 {%- macro oneLoginIcon(modifier="default") -%}
   {%- set class = "rebranded-cross-service-header__logo--nav" if modifier == "nav" else "" %}
-  <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo {{class}}">
+  <svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo {{class}}" aria-hidden="true">
     <path d="M300.002 312.261C249.445 312.261 208.346 271.165 208.346 220.608C208.346 170.051 249.445 128.954 300.002 128.954C350.559 128.954 391.655 170.051 391.655 220.608C391.655 271.165 350.559 312.261 300.002 312.261ZM300.002 170.892C272.673 170.892 250.389 193.175 250.389 220.504C250.389 247.83 272.673 270.113 300.002 270.113C327.33 270.113 349.611 247.83 349.611 220.504C349.611 193.175 327.33 170.892 300.002 170.892Z" />
     <path d="M221.275 471.046H179.231V365.202H420.769V407.246H221.275V471.046Z"/>
   </svg>

--- a/dist/preview-rebranded.html
+++ b/dist/preview-rebranded.html
@@ -76,7 +76,7 @@
         class="rebranded-cross-service-header__toggle js-x-header-toggle">
         <span class="rebranded-cross-service-header__toggle-content-wrapper">
           
-  <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo ">
+  <svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo " aria-hidden="true">
     <path d="M300.002 312.261C249.445 312.261 208.346 271.165 208.346 220.608C208.346 170.051 249.445 128.954 300.002 128.954C350.559 128.954 391.655 170.051 391.655 220.608C391.655 271.165 350.559 312.261 300.002 312.261ZM300.002 170.892C272.673 170.892 250.389 193.175 250.389 220.504C250.389 247.83 272.673 270.113 300.002 270.113C327.33 270.113 349.611 247.83 349.611 220.504C349.611 193.175 327.33 170.892 300.002 170.892Z" />
     <path d="M221.275 471.046H179.231V365.202H420.769V407.246H221.275V471.046Z"/>
   </svg>
@@ -89,7 +89,7 @@
             <a class="rebranded-one-login-header__nav__link" href="https://home.account.gov.uk/">
               <span class="rebranded-one-login-header__nav__link-content">
                 
-  <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo rebranded-cross-service-header__logo--nav">
+  <svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo rebranded-cross-service-header__logo--nav" aria-hidden="true">
     <path d="M300.002 312.261C249.445 312.261 208.346 271.165 208.346 220.608C208.346 170.051 249.445 128.954 300.002 128.954C350.559 128.954 391.655 170.051 391.655 220.608C391.655 271.165 350.559 312.261 300.002 312.261ZM300.002 170.892C272.673 170.892 250.389 193.175 250.389 220.504C250.389 247.83 272.673 270.113 300.002 270.113C327.33 270.113 349.611 247.83 349.611 220.504C349.611 193.175 327.33 170.892 300.002 170.892Z" />
     <path d="M221.275 471.046H179.231V365.202H420.769V407.246H221.275V471.046Z"/>
   </svg>

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -33,7 +33,7 @@ Component options:
 
 {%- macro oneLoginIcon(modifier="default") -%}
   {%- set class = "rebranded-cross-service-header__logo--nav" if modifier == "nav" else "" %}
-  <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo {{class}}">
+  <svg focusable="false" xmlns="http://www.w3.org/2000/svg" width="15" height="30" viewBox="150 150 250 250" fill="currentcolor" class="rebranded-cross-service-header__logo {{class}}" aria-hidden="true">
     <path d="M300.002 312.261C249.445 312.261 208.346 271.165 208.346 220.608C208.346 170.051 249.445 128.954 300.002 128.954C350.559 128.954 391.655 170.051 391.655 220.608C391.655 271.165 350.559 312.261 300.002 312.261ZM300.002 170.892C272.673 170.892 250.389 193.175 250.389 220.504C250.389 247.83 272.673 270.113 300.002 270.113C327.33 270.113 349.611 247.83 349.611 220.504C349.611 193.175 327.33 170.892 300.002 170.892Z" />
     <path d="M221.275 471.046H179.231V365.202H420.769V407.246H221.275V471.046Z"/>
   </svg>


### PR DESCRIPTION


### What changed
The "OL sideways" icon is purely decorative in the context of the cross-service header.
Labelling it with alt text or with a title would only add noise for AT users, as the visual element is already accompanied by descriptive text ("GOV.UK One Login").

Adding `aria-hidden` ensures the element is always hidden for AT. The `role` attribute became redundant in this context so it's been removed.
<!-- Describe the changes in detail - the "what"-->

### Testing
Run `npm run dev` locally. Navigate to http://localhost:8080/dist/preview-rebranded.html and use WAVE extension to generate an accessibility evaluation. And/or use a screen reader of your choice to navigate the page manually. 