### PR TITLE
BAU: Add command to install package from Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ Instructions on how the header can be installed in your Prototype Kit project ar
 
 ## How to start using the header in your service
 
-NOTE: If your service uses Nunjucks, you can use NPM to install the header direct from GitHub, and import the Nunjucks macro directly from `/dist/nunjucks/di-govuk-one-login-service-header/service-header.njk`. Some of the instructions below will seem redundant in your case.
+> NOTE: If your service uses Nunjucks, you can use NPM to install the header direct from GitHub by running
+>
+> ```sh
+> npm install github:govuk-one-login/service-header@3.1.1
+> ```
+>
+> Then import the Nunjucks macro directly from `/di-govuk-one-login-service-header/service-header.njk`. Some of the instructions below will seem redundant in your case.
 
 This repository contains:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Instructions on how the header can be installed in your Prototype Kit project ar
 > NOTE: If your service uses Nunjucks, you can use NPM to install the header direct from GitHub by running
 >
 > ```sh
+> npm install github:govuk-one-login/service-header
+> ```
+>
+>or to install a specific version from the tag
+> ```sh
 > npm install github:govuk-one-login/service-header@3.1.1
 > ```
 >


### PR DESCRIPTION
### What changed

Add the command to install this package from Github to the README. This is just a documentation change.

### Why did it change

We refer to being able to do this but didn't provide the command. This leads to some confusion (eg. see [^1]). Add the command to the README so people don't need to ask us about it.

[^1]: https://ukgovernmentdigital.slack.com/archives/C02AQUJ6WTC/p1756307642419769

