### PR TITLE
BAU: Fix GH pages deployment issue

### DIFF
--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -56,7 +56,7 @@ To overwrite the destination for the One Login link in the header, use <code>&lb
 
 To overwrite the destination for the sign out link in the header, use <code>&lbrace;&percnt; set signOutLink = "https://example.service.gov.uk/sign-out" &percnt;&rbrace;</code>. The link goes to "https://home.account.gov.uk/sign-out" by default.
 
-To set header language to Welsh, use {% set lng = "cy" %}. 
+To set header language to Welsh, use &lbrace;&percnt; set lng = "cy" &percnt;&rbrace;. 
 
 Add the `set` statements listed above after the `extends` line at the top of the file.
 


### PR DESCRIPTION
The Deploy to GH pages action is failing on main due to merging in documentation updates which include nunjucks syntax.

This is happening because the templating language used by GH pages uses similar but not identical syntax. 
This results in a [Liquid syntax error in the build step](https://github.com/govuk-one-login/service-header/actions/runs/18947310453/job/54102193735).

Using HTML character entities instead of the Nunjucks `{% %}` tags should fix this. 