### PR TITLE
OLH-4063: Remove service nav component from service header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Use [semver guidelines](https://semver.org/).
 ## Unreleased
 
 - Update govuk-frontend to v6.1.0 ([PR #114](https://github.com/govuk-one-login/service-header/pull/114))
+- OLH-4063: Remove service nav component from service header ([PR #130](https://github.com/govuk-one-login/service-header/pull/130))
 
 ## 5.0.0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides a way for users to:
 + sign out
 + change their sign in credentials
 
-The One Login header has been adapted from the [standard service header in the GOV.UK Design System](https://design-system.service.gov.uk/components/header/).
+The GOV.UK One Login header has been adapted from the [standard header in the GOV.UK Design System](https://design-system.service.gov.uk/components/header/).
 
 It's a 'beta' component and we're interested to hear from service teams about how it performs with your users.
 
@@ -33,11 +33,11 @@ Within GDS: use the #di-one-login-home channel
 
 ## What different parts of the header do
 
-The header contains two distinct navigation menus - one for GOV.UK One Login links and another for internal service navigation, which uses the Design System [service navigation component](https://design-system.service.gov.uk/components/service-navigation/).
+The header previously contained two distinct navigation menus - one for GOV.UK One Login links and another for internal service navigation, which uses the Design System [service navigation component](https://design-system.service.gov.uk/components/service-navigation/).
 
-On smaller screens, both menus collapse and can be shown and hidden using Javascript.
+As of service header version 6.0.0, the service navigation was decoupled from the main GOV.UK One Login header.
 
-You’ll need to adapt the internal service navigation so that it includes content specific to your service. This includes adapting the accessibility markup in the internal service navigation.
+You’ll need to add the Design System [service navigation component](https://design-system.service.gov.uk/components/service-navigation/) separately (including its CSS and Javascript), and adapt it to include content specific to your service.
 
 ### GOV.UK One Login links in the header
 
@@ -45,10 +45,6 @@ The header contains two links:
 
 + "GOV.UK One Login": this takes the user to their One Login ‘home’ area, where they can manage their credentials and see and access the services they've used - you don't need to update the url this points to
 + "Sign out": you'll need to adapt this link so that it signs the user out of your service and signs them out of One Login - how you do this will depend on how you've implemented sign out functionality in your service 
-
-### Internal service navigation links in the header
-
-The header has space to optionally add links to different parts of your service, just as the current ‘service header’ component from the Design System does. Follow the same patterns for internal service navigation links as you do with the Design System service header.
 
 ## How to use the header in a Prototype Kit prototype
 
@@ -80,14 +76,12 @@ If your service does not use Nunjucks, download and unzip the source code attach
 The package contains:
 
 + Nunjucks for the GOV.UK One Login service header component 
-+ plain HTML for the header - this is compiled from the Nunjucks into the `dist/html` directory
-+ Sass files for compiling CSS files to style the header (this covers both navigation bars)
++ plain HTML for the header - this is compiled from the Nunjucks into the `/dist/html` directory
++ Sass files for compiling CSS files to style the header
 + plain CSS, for services who are not using Sass
 + a Javascript file which enables 'drop down' behaviour for the GOV.UK One Login and Sign out links on small screens
 
-To enable drowdown behaviour for the service navigation links, you will need to import the service navigation component script from the Design System (or GOV.UK Frontend). Instructions on importing scripts from the Design System are outlined [on this page](https://frontend.design-system.service.gov.uk/import-javascript/)
-
-Further documentation on the service navigation component is available [on this page](https://design-system.service.gov.uk/components/service-navigation/).
+You will need to import the service navigation component from the Design System (or GOV.UK Frontend). Follow the guidance on the service navigation component [documentation page](https://design-system.service.gov.uk/components/service-navigation/).
 
 You will need to make additional changes to your service and to the header code for it to function correctly.
 
@@ -95,7 +89,7 @@ You will need to:
 
 + write logic within your service so that the header is only shown to users who are signed in
 + adapt the header's HTML so that it works in the templating language your service uses (if your service does not use Nunjucks)
-+ adapt the internal service navigation HTML so that it includes content specific to your service
++ adapt the service navigation HTML so that it includes content specific to your service
 + point the 'Sign out' link at your service's sign out endpoint
 + include the styling and Javascript files in your service
 
@@ -115,17 +109,16 @@ The Nunjucks code will work with the [GOV.UK Prototype Kit](https://prototype-ki
 
 ### Adapt the internal service navigation HTML so that it includes content specific to your service
 
-You'll need to modify the internal service navigation part of the header in order to:
+You'll need to adapt the service navigation component in order to:
 
 + visually highlight which page in the menu the user is currently on
 + ensure screen reader text and ARIA attributes are specific to your service
 
-#### Visually highlight which page in the menu the user is currently on
+### Nunjucks macro implementation
 
-You can visually highlight the page the user is currently on in the navigation menu by adding the `govuk-service-navigation__item--active` modifier class to the relevant `li` element in the service navigation menu. You’ll need to implement this in the code you’re using to render your pages. 
+Before service header 6.0.0, the service navigation was integrated into `govukOneLoginServiceHeader`:
 
-If you are using the Nunjucks macro, you can pass options into the service navigation using `serviceNavigationParams` like so:
-
+#### Before (deprecated)
 <pre><code>
 &lbrace;&lbrace; govukOneLoginServiceHeader(&lbrace;
   signOutLink: "/placeholder", 
@@ -136,53 +129,60 @@ If you are using the Nunjucks macro, you can pass options into the service navig
 &rbrace;&rbrace;) &rbrace; &rbrace; 
 </code></pre>
 
-`serviceNavigationParams` accepts all the options listed under "Nunjucks macro options" on the [service navigation component page](https://design-system.service.gov.uk/components/service-navigation/).
+As of service header 6.0.0, the `govukOneLoginServiceHeader` and `govukServiceNavigation` have been decoupled. Please make changes to include them separately, as below. Note that you must specify a `serviceName`.
+
+#### After
+
+<pre><code>
+&lbrace;&lbrace; govukOneLoginServiceHeader(&lbrace;
+  signOutLink: "/placeholder"&rbrace;) &rbrace; &rbrace;
+
+&lbrace;&lbrace; govukServiceNavigation(&lbrace;
+  serviceName: "Service name",
+  serviceUrl: "#",
+  navigation: [
+    {
+      href: "#",
+      text: "Navigation item 1"
+    },
+    {
+      href: "#",
+      text: "Navigation item 2",
+      active: true
+    },
+    {
+      href: "#",
+      text: "Navigation item 3"
+  }] &rbrace;) &rbrace; &rbrace; 
+</code></pre>
+
+### Accessibility considerations
 
 #### Edit screen reader text and ARIA attributes to be specific to your service
 
-The header is designed to work for users of screen readers and contains some visually hidden text and [ARIA attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) which you will need to edit to make it specific to your service.
-
-You’ll need to edit the markup (or pass relevant parameters into the Nunjucks macro) for the:
+If your service includes the service navigation component, you might need to edit the markup (or pass relevant parameters into the Nunjucks macro) for the:
 
 + ‘menu’ button
 + service navigation
 + page the user is currently on in the service navigation
 
+Refer to the Design System Service navigation component [documentation page](https://design-system.service.gov.uk/components/service-navigation/) for guidance.
+
 #### Edit accessibility markup for the ‘menu’ button
 
-The menu button is used to show or hide the internal service navigation menu of the header on small devices.
-
-You’ll need to adapt the screen reader text for the following attributes of the menu button element:
-
-+ `aria-label`
-+ `data-label-for-show`
-+ `data-label-for-hide`
-
-In this repository, the values for these attributes refer to the “service navigation menu”. You should adapt this text to describe your service’s navigation menu. For example, you could update `data-label-for-show` to have the value “Show Juggling Licence service navigation menu”.
-
-This is to help users understand which navigation menu they are opening and closing.
+Follow Design System guidance on customising the label for the Service navigation component Menu button. 
 
 #### Edit accessibility markup for the internal service navigation menu
 
 The service navigation menu contains links to help users navigate your service. It’s distinct from the One Login navigation menu which lets users access One Login and sign out.
 
-You’ll need to adapt the screen reader text for the `aria-label` attribute of the service navigation menu element.
-
-In this repository, the value for this attribute refers to the “Service menu”. You should adapt this text to be specific to your service. For example, you could set the text to “Juggling Licence service navigation menu”.
+If your service includes a service navigation, you need to adapt the screen reader text for the `aria-label` attribute of the service navigation `<nav>` element.
 
 This is to help users understand which navigation menu they are using. It also helps meet the WCAG requirement that navigation landmarks must be labelled when there is more than one `nav` element on the page, to describe the navigation to users who may be navigating the site using landmarks.
 
-#### Edit accessibility markup for the navigation menu page the user is currently on
-
-You can [visually highlight the page the user is currently on in the navigation menu](#visually-highlight-which-page-in-the-menu-the-user-is-currently-on).
-
-In addition to this, set the `aria-current="true"` attribute on the relevant `<a>` element.
-
-This is to indicate the user’s position in the navigation if they can’t perceive the visual highlight styling.
-
 ### Point the 'Sign out' link at your service's sign out endpoint
 
-The One Login header contains a ‘Sign out’ link. You’ll need to update this so that it calls the endpoint your service uses to sign users out.
+The GOV.UK One Login header contains a ‘Sign out’ link. You’ll need to update this so that it calls the endpoint your service uses to sign users out.
 
 There’s documentation about how to sign users out in the main [GOV.UK One Login technical documentation](https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/managing-your-users-sessions/#log-your-user-out-of-gov-uk-one-login). It covers how to:
 
@@ -253,8 +253,8 @@ A basic working example using `service-header.js` can be seen on the [header pre
 
 The header degrades gracefully in the absence of Javascript (for example, if a user has turned Javascript off or the code does not load). Without Javascript:
 
-+ both navigation menus will be in their ‘dropped down’ states
-+ the menu toggle buttons will not display (they wouldn't be functional without Javascript)
++ the navigation menu will be in its ‘dropped down’ state
++ the menu toggle button will not display (it wouldn't be functional without Javascript)
 
 ## Translating the header content into other languages
 

--- a/build.cjs
+++ b/build.cjs
@@ -1,30 +1,10 @@
 const fs = require('fs');
 const nunjucks = require('nunjucks');
 
-var params =  { 
-  serviceNavigationParams: {
-  serviceName: "Name of example service", 
-  navigation: [
-    {
-      href: "#navigation1",
-      text: "Navigation item 1"
-    },
-    {
-      href: "#navigation2",
-      text: "Navigation item 2",
-      active: true
-    },
-    {
-      href: "#navigation3",
-      text: "Navigation item 3"
-    }
-  ] 
-}}
-
 // generate header HTML preview from nunjucks
 const previewHtml = nunjucks.render("src/preview.njk");
 // generate header HTML from the nunjucks template
-const headerHtml = nunjucks.render("src/nunjucks/template.njk", { params: params });
+const headerHtml = nunjucks.render("src/nunjucks/template.njk");
 
 fs.mkdirSync(__dirname + '/dist', { recursive: true });
 fs.mkdirSync(__dirname + '/dist/html', { recursive: true });

--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -17,39 +17,6 @@ To create a page in your prototype using a pre-built template containing the hea
 
 ![List of templates available to install on the Prototype Kit templates page](assets/prototype-kit/templates.png)
 
-To set the service name that is displayed in the header, use the following syntax: <code>&lbrace;&percnt; set serviceName = "My example service name" &percnt;&rbrace;</code>.
-
-As of v3.0.0 of the GOV.UK One Login Service Header, it includes the Design System [service navigation component](https://design-system.service.gov.uk/components/service-navigation/).
-If you are using the latest version of the GOV.UK One Login Service Header, please make sure the GOV.UK Frontend plugin has also been updated to the latest version. You might experience errors otherwise.
-
-The options in the Nunjucks macro options table on the Design System service navigation component page can be defined as Nunjucks template variables.
-
-For example, <code>&lbrace;&percnt; set menuButtonText = "Custom Menu Button" &percnt;&rbrace;</code> will change the text of the service navigation mobile navigation menu toggle.
-
-To set the list of navigation links , use the following syntax:
-<pre><code>
-&lbrace;&percnt; set navigation = [
-    {
-      href: "#nav1",
-      text: "Navigation item 1"
-    },
-    {
-      href: "#nav2",
-      text: "Navigation item 2",
-      active: true
-    },
-    {
-      href: "#nav3",
-      text: "Navigation item 3"
-    }
-  ]
-&percnt;&rbrace; 
-</code></pre>
-The fields indicate as follows:
-- `href` indicates the link destination, 
-- `text` is the text being displayed, 
-- `active` this is an optional parameter which indicates that the user is within this group of pages in the navigation hierarchy. It adds an underline to the link.
-
 To overwrite the destination for the GOV.UK link in the header, use <code>&lbrace;&percnt; set homepageLink = "https://example.service.gov.uk/" &percnt;&rbrace;</code>. The link goes to "https://www.gov.uk/" by default.
 
 To overwrite the destination for the One Login link in the header, use <code>&lbrace;&percnt; set oneLoginLink = "https://example.service.gov.uk/" &percnt;&rbrace;</code>. The link goes to "https://home.account.gov.uk/" by default.
@@ -59,6 +26,8 @@ To overwrite the destination for the sign out link in the header, use <code>&lbr
 To set header language to Welsh, use &lbrace;&percnt; set lng = "cy" &percnt;&rbrace;. 
 
 Add the `set` statements listed above after the `extends` line at the top of the file.
+
+To customise the service navigation component, follow the instructions on this [page](https://prototype-kit.service.gov.uk/docs/how-to-use-layouts).
 
 ## Use the header component in an existing page or template
 
@@ -71,6 +40,7 @@ The component can then be used like so:
   &lbrace;&lbrace; govukOneLoginServiceHeader({
     signOutLink: "/test-signout",
     oneLoginLink: "/test-one-login",
+    homepageLink: "/your-prototype-homepage",
     lng: "cy"
   }) &rbrace;&rbrace;
 &lbrace;&percnt; endblock &percnt;&rbrace;

--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -71,24 +71,44 @@ The component can then be used like so:
   &lbrace;&lbrace; govukOneLoginServiceHeader({
     signOutLink: "/test-signout",
     oneLoginLink: "/test-one-login",
-    lng: "cy",
-    serviceNavigationParams: { 
-      navigation: [
-      {
-        href: "#navigation1", 
-        text: "Navigation item 1" 
-      },{
-        href: "#navigation2", 
-        text: "Navigation item 2",
-        active: true
-      },{
-        href: "#navigation3", 
-        text: "Navigation item 3"
-      }], 
-      serviceName: "Test service name",
-      navigationLabel: "Test label" 
-    }
+    lng: "cy"
   }) &rbrace;&rbrace;
+&lbrace;&percnt; endblock &percnt;&rbrace;
+</code></pre>
+
+As of service header version 6.0.0, the service navigation component has been decoupled from the GOV.UK One Login service header.
+
+If your service requires a service navigation, please import the [service navigation component](https://design-system.service.gov.uk/components/service-navigation/) from the Design System.
+
+Add it separately, after the `govukOneLoginServiceHeader`, as follows:
+
+<pre><code>
+&lbrace;&percnt; block govukHeader &percnt;&rbrace;
+  &lbrace;&lbrace; govukOneLoginServiceHeader({
+    signOutLink: "/test-signout",
+    oneLoginLink: "/test-one-login",
+    lng: "cy"
+  }) &rbrace;&rbrace;
+
+  &lbrace;&lbrace; govukServiceNavigation({
+  serviceName: "Service name",
+  serviceUrl: "#",
+  navigation: [
+    {
+      href: "#",
+      text: "Navigation item 1"
+    },
+    {
+      href: "#",
+      text: "Navigation item 2",
+      active: true
+    },
+    {
+      href: "#",
+      text: "Navigation item 3"
+    }
+  ]
+}) &rbrace;&rbrace;
 &lbrace;&percnt; endblock &percnt;&rbrace;
 </code></pre>
 

--- a/src/nunjucks/layouts/service-header.njk
+++ b/src/nunjucks/layouts/service-header.njk
@@ -2,63 +2,13 @@
 {% from "../service-header.njk" import govukOneLoginServiceHeader %}
 
 {% block govukHeader %}
-    {%- if navigationItems -%}
-      {%- set navArr = [] -%}
-      {%- for item in navigationItems -%}
-        {{- '' if navArr.push({
-            href: item.href,
-            text: item.text,
-            active: item.id == activeLinkId
-        }) -}}
-      {%- endfor -%}
-      {{ govukOneLoginServiceHeader({
-        serviceNavigationParams: {
-          serviceName: serviceName,
-          lng: lng,
-          serviceUrl: serviceUrl,
-          menuButtonText: menuButtonText,
-          menuButtonLabel: menuButtonLabel,
-          navigation: navArr,
-          navigationLabel: navigationLabel,
-          navigationClasses: navigationClasses,
-          attributes: attributes,
-          classes: classes,
-          ariaLabel: ariaLabel,
-          collapseNavigationOnMobile: collapseNavigationOnMobile
-        },
-        signOutLink: signOutLink,
-        oneLoginLink: oneLoginLink
-      }) if serviceName }}
-    {%- elif navigation -%}
-      {{ govukOneLoginServiceHeader({
-        signOutLink: signOutLink,
-        lng: lng,
-        oneLoginLink: oneLoginLink,
-        serviceNavigationParams: {
-          serviceName: serviceName,
-          serviceUrl: serviceUrl,
-          navigation: navigation,
-          menuButtonText: menuButtonText,
-          menuButtonLabel: menuButtonLabel,
-          navigationLabel: navigationLabel,
-          navigationClasses: navigationClasses,
-          attributes: attributes,
-          classes: classes,
-          ariaLabel: ariaLabel,
-          collapseNavigationOnMobile: collapseNavigationOnMobile
-        }
-      }) if serviceName }}
-    {%- else -%}
-      {{ govukOneLoginServiceHeader({ 
-        serviceName: serviceName, 
-        lng: lng,
-        serviceUrl: serviceUrl,
-        signOutLink: signOutLink,
-        oneLoginLink: oneLoginLink,
-        menuButtonText: menuButtonText,
-        menuButtonLabel: menuButtonLabel
-      })}}
-    {%- endif -%}
+  {{ govukOneLoginServiceHeader({ 
+    lng: lng,
+    signOutLink: signOutLink,
+    oneLoginLink: oneLoginLink,
+    menuButtonText: menuButtonText,
+    menuButtonLabel: menuButtonLabel
+  })}}
 {% endblock %}
 
 {% block main %}

--- a/src/nunjucks/layouts/service-header.njk
+++ b/src/nunjucks/layouts/service-header.njk
@@ -6,8 +6,7 @@
     lng: lng,
     signOutLink: signOutLink,
     oneLoginLink: oneLoginLink,
-    menuButtonText: menuButtonText,
-    menuButtonLabel: menuButtonLabel
+    homepageLink: homepageLink
   })}}
 {% endblock %}
 

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -4,12 +4,10 @@ Component options:
   - signOutLink (string): Option to overwrite the default signed out page. Defaults to "https://home.account.gov.uk/sign-out"
   - lng (string): Option to overwrite the default language. Defaults to English unless "cy" is specified for Welsh.
   - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://home.account.gov.uk/"
-  - serviceNavigationParams (object): Options for the service navigation component. Accepts all the options listed under "Nunjucks macro options" on the Design System [service navigation component page](https://design-system.service.gov.uk/components/service-navigation/). The service nav bar will not render unless serviceName is specified
   - signOutFormAction (string): For services that require a POST request to sign out, this option allows you to set the form action URL for the sign out form. If this option is provided, the "Sign out" link will be rendered as a form that submits a POST request to the specified URL. Overrules `signOutLink` option if both are provided.
   - signOutFormHiddenInputsHtml (html string): Option to add hidden input fields to the sign out form. This is useful for including CSRF tokens or other necessary hidden data when using a POST request for signing out.
 
 #}
-{%- from "node_modules/govuk-frontend/dist/govuk/components/service-navigation/macro.njk" import govukServiceNavigation -%}
 {%- set lngQueryString = "?lng=cy" if (params.lng === "cy") else "" -%}
 {%- set signOutLinkText = "Allgofnodi" if (params.lng === "cy") else "Sign out" -%}
 {%- set oneLoginLink = params.oneLoginLink if params.oneLoginLink else (["https://home.account.gov.uk", lngQueryString] | join) -%}
@@ -97,12 +95,4 @@ Component options:
       </nav>
     </div>
   </div>
-  <!-- Start of service navigation -->
-  <!-- This is a DESIGN SYSTEM component with a dependency on Javascript  -->
-  <!-- Javascript is necessary to enable dropdown functionality for the list of links on mobile -->
-  <!-- Import the latest version of the script for this component using the instructions here https://frontend.design-system.service.gov.uk/import-javascript/#import-javascript  -->
-    {%- if params.serviceNavigationParams -%}
-       {{ govukServiceNavigation(params.serviceNavigationParams) if params.serviceNavigationParams.serviceName }}
-    {%- endif -%}
-  <!-- End of service navigation -->
 </div>

--- a/src/preview.njk
+++ b/src/preview.njk
@@ -60,44 +60,7 @@
     </header>
 
     <div class="govuk-!-padding-3 govuk-!-margin-top-8">
-      <h2 class="govuk-heading-m">2. With Service Navigation component </h2>
-
-      <details class="govuk-details">
-        <summary>Nunjucks code</summary>
-        <pre><code>
-        {% raw %}
-          {{ govukOneLoginServiceHeader({
-            signOutLink:  "/test", 
-            serviceNavigationParams: { 
-              navigation: [
-              {
-                href: "#navigation1", 
-                text: "Navigation item 1" 
-              },{
-                href: "#navigation2", 
-                text: "Navigation item 2",
-                active: true
-              },{
-                href: "#navigation3", 
-                text: "Navigation item 3"
-              }], 
-              serviceName: "A very useful service with a relatively long name", 
-              navigationLabel: "Test label" 
-            }
-          })}}
-        {% endraw %}
-        </code></pre>
-      </details>
-      <p class="govuk-body"> The code above is for reference for Nunjucks users only – if you do not use Nunjucks in your service please follow the <a class="govuk-link" href="https://github.com/govuk-one-login/service-header/tree/main?tab=readme-ov-file#how-to-start-using-the-header-in-your-service"> instructions to copy the header into your service</a>.</p>
-    </div>
-    <header>
-
-    {{ govukOneLoginServiceHeader({ signOutLink: signOutLink, serviceNavigationParams: { navigation: navigation, serviceName: serviceName, navigationLabel: "Test" } }) }}
-    </header>
-
-
-    <div class="govuk-!-padding-3 govuk-!-margin-top-8">
-      <h2 class="govuk-heading-m">3. With Welsh translation for the "Sign out" link</h2>
+      <h2 class="govuk-heading-m">2. With Welsh translation for the "Sign out" link</h2>
 
       <details class="govuk-details">
         <summary>Nunjucks code</summary>
@@ -124,7 +87,7 @@
         {% raw %}
           {{ govukOneLoginServiceHeader({
             signOutFormAction: "/test-form-action",
-            signOutFormHiddenInputsHtml: '<input type="hidden" name="csrfToken" value="exampleCsrfToken12345">'
+            signOutFormHiddenInputsHtml: '&lt;input type="hidden" name="csrfToken" value="exampleCsrfToken12345"&gt;'
           })}}
         {% endraw %}
         </code></pre>

--- a/src/styles/service-header.scss
+++ b/src/styles/service-header.scss
@@ -4,7 +4,6 @@
 @import "govuk/base";
 @import "govuk/objects/width-container";
 @import "govuk/objects/grid";
-@import "govuk/components/service-navigation";
 
 // end dependencies from GOVUK frontend
 


### PR DESCRIPTION
### What changed

Remove service navigation component from service header, updating documentation to guide users towards installing this component directly from the Design System instead.
<!-- Describe the changes in detail - the "what"-->

### Why did it change

The service navigation used to be a custom component but has since been introduced into the Design System.

As of [version 6 of the Design System](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0), breaking changes have been introduced to template structure and the govuk-frontend nunjucks blocks, where the header tag and the actual Header component(s) have been decoupled. This allows users greater flexibility and lets them customise/control elements which go inside the `<header>` tag. 

This removes the requirement to have the service navigation component be part of the GOV.UK One Login service header component. The blue bar with the GOVUK OL nav is the only custom, OL specific thing.
<!-- Describe the reason these changes were made - the "why" -->

### Testing
Tested locally on [the preview page](http://localhost:8080/dist/preview.html) and within a local prototype kit project.
<!-- Outline any testing you have done and any testing that needs to take place -->
