### PR TITLE
BAU: workflow tweaks and dev documentation updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,6 @@
 ### Checklists
 - [ ] design changes have been reviewed by a member of the UCD team
 - [ ] the CHANGELOG.md file has been updated with a log of the changes in this PR
-- [ ] the `npm run build-all` task was run and the outputs were committed
 
 ### Testing
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Upload Release Asset
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:

--- a/docs/dev-contribution-notes.md
+++ b/docs/dev-contribution-notes.md
@@ -24,14 +24,15 @@ There is a `watch-sass` script which is fairly self-explanatory.
 
 ## Before you open a PR
 
-1. Ensure you've `npm run build-all` and committed the outputs. This generates the contents of the `/dist` folder.
-2. Ensure your change is documented in the `CHANGELOG`, following the preexisting format. Please label your entry with BUG/MAJOR/MINOR.
+Ensure your change is documented in the `CHANGELOG`, following the preexisting format. Please label your entry with BUG/MAJOR/MINOR.
 If you're not sure which label is most appropriate, please read the guidance on [semver guidelines](https://semver.org/).
 You don't need to document any change that would be irrelevant for an external consumer of the component (e.g. changes to internal documentation).
 
 ## Publishing a new version to NPM
 
-The package is automatically published to NPM when a new release is created on GitHub.
+When a new release is created on GitHub, two things happen:
+1. The package is automatically published to NPM
+2. A zipped version of the build output (`dist` folder) is created and attached to the GitHub Release
 
 To publish a new version:
 


### PR DESCRIPTION
### What changed

1. Updated workflow triggers

When I recently created a draft release and published it later, I noticed that the release to npm and upload asset Github actions were not running. I had to delete and recreate the release (this time publishing it straight away instead of saving as a draft first).

It turns out `on: release: types: [created]` does not trigger when a release is originally created as a draft and published later.
Having read up about it, it sounds like `published` is the standard choice for automation that only happens once a release is "final" and visible to the public. 

2. Minor doc updates

To reflect recent changes in process.

<!-- Describe the changes in detail - the "what"-->

