### PR TITLE
BAU: add dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,8 @@ updates:
     labels:
       - dependabot
       - dependencies
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Add minor/patch grouping to dependabot ecosystems that were previously ungrouped, reducing the number of individual PRs created per cycle.

Groups added:
- pip: `pip-minor-patch`

Major version bumps are excluded from all groups and will continue to get individual PRs as they are more likely to contain breaking changes.