### PR TITLE
BAU: Fix alignment issue in prototype kit layout template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Use [semver guidelines](https://semver.org/).
 
+## Unreleased
+
+- PATCH: BAU: Fix alignment issue in prototype kit layout template
+
 ## 6.0.0
 
 - Update govuk-frontend to v6.1.0 ([PR #114](https://github.com/govuk-one-login/service-header/pull/114))

--- a/src/nunjucks/layouts/service-header.njk
+++ b/src/nunjucks/layouts/service-header.njk
@@ -10,7 +10,7 @@
   })}}
 {% endblock %}
 
-{% block main %}
+{% block container %}
   <div class="govuk-width-container">
     {% block beforeContent %}{% endblock %}
     <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content">


### PR DESCRIPTION
### What changed
Update layout template for prototype kit to reflect changes to nunjucks blocks which were introduced in `govuk-frontend` v6+.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Using the `main` block in this way resulted in additional margins being added on smaller screen sizes. The `container` block should be used instead.
<!-- Describe the reason these changes were made - the "why" -->


### Checklists
- [ ] design changes have been reviewed by a member of the UCD team (N/A)
- [x] the CHANGELOG.md file has been updated with a log of the changes in this PR

### Testing
Tested with a local prototype kit project. Note alignment of page content relative to header content:

#### Before

<img width="980" height="558" alt="Screenshot 2026-07-03 at 11 16 01" src="https://github.com/user-attachments/assets/2e71a2d9-1959-40df-bedc-20981944f55a" />

#### After

<img width="1322" height="508" alt="Screenshot 2026-07-03 at 11 12 42" src="https://github.com/user-attachments/assets/33beccef-b513-412e-8521-d19995b889dc" />

<!-- Outline any testing you have done and any testing that needs to take place -->
